### PR TITLE
CuentaCorriente 

### DIFF
--- a/src/cuenta-corriente/cuenta-corriente.service.ts
+++ b/src/cuenta-corriente/cuenta-corriente.service.ts
@@ -180,13 +180,13 @@ export class CuentaCorrienteService {
       }
 
       const cuentaCorriente = await em.findOne(CuentaCorriente, {
-        where: { id: clienteId },
+        where: { cliente: { id: clienteId } },
         relations: ['movimientos'],
       });
 
       if (!cuentaCorriente) {
         throw new NotFoundException(
-          `Cuenta corriente con id ${clienteId} no encontrada`,
+          `Cuenta corriente con cliente ${clienteId} no encontrada`,
         );
       }
 


### PR DESCRIPTION
Modifica la lógica de búsqueda en el servicio de CuentaCorriente para utilizar la relación con el cliente en lugar del ID directo. Se actualiza el mensaje de excepción para reflejar el cambio en la búsqueda.