### PR TITLE
Se corrige la consulta en el servicio de productos para utilizar 'prducto.codProv' en lugar de 'producto.cod', mejorando la precisión en la búsqueda de códigos.

### DIFF
--- a/src/producto/producto.service.ts
+++ b/src/producto/producto.service.ts
@@ -58,7 +58,7 @@ export class ProductoService {
       }
       if (cod) {
         queryBuilder.andWhere(
-          'producto.cod COLLATE Latin1_General_CI_AI LIKE :cod',
+          'producto.codProv COLLATE Latin1_General_CI_AI LIKE :cod',
           { cod: `%${cod.trim()}%` },
         );
       }


### PR DESCRIPTION
…